### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ pip install opencv-python pycocotools matplotlib onnxruntime onnx
 Start 3D Slicer, in the Python Console:
 
 ```python
-import pip
-pip.main(['install', 'pyyaml'])
-pip.main(['install', 'pyzmq'])
+slicer.util.pip_install("pyyaml")
+slicer.util.pip_install("pyzmq")
 ```
 
 SD Slicer -> `Developer Tools` &rarr; `Extension Wizard`.


### PR DESCRIPTION
The old way causes a lot of warnings in a recent Slicer:

```log
Python 3.9.10 (main, Mar 23 2023, 23:31:17) [MSC v.1930 64 bit (AMD64)] on win32
>>> 
import pip
pip.main(['install', 'pyyaml'])
pip.main(['install', 'pyzmq'])
Setuptools is replacing distutils.
WARNING: pip is being invoked by an old script wrapper. This will fail in a future version of pip.
Please see https://github.com/pypa/pip/issues/5599 for advice on fixing the underlying issue.
To avoid this problem you can invoke Python with '-m pip' instead of running pip directly.
--- Logging error ---
Traceback (most recent call last):
  File "<string>", line 60, in emit
KeyError: 15
Call stack:
  File "<string>", line 2, in <module>
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\__init__.py", line 13, in main
    return _wrapper(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\entrypoints.py", line 43, in _wrapper
    return main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main.py", line 55, in main
    cmd_name, cmd_args = parse_command(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main_parser.py", line 79, in parse_command
    general_options, args_else = parser.parse_args(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\optparse.py", line 1371, in parse_args
    values = self.get_default_values()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\parser.py", line 279, in get_default_values
    self.config.load()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 124, in load
    self._load_config_files()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 255, in _load_config_files
    parser = self._load_file(variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 261, in _load_file
    logger.verbose("For variant '%s', will try loading '%s'", variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\_log.py", line 23, in verbose
    return self.log(VERBOSE, msg, *args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1512, in log
    self._log(level, msg, args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1589, in _log
    self.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 952, in handle
    self.emit(record)
  File "<string>", line 62, in emit
Message: "For variant '%s', will try loading '%s'"
Arguments: ('global', 'C:\\ProgramData\\pip\\pip.ini')
--- Logging error ---
Traceback (most recent call last):
  File "<string>", line 60, in emit
KeyError: 15
Call stack:
  File "<string>", line 2, in <module>
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\__init__.py", line 13, in main
    return _wrapper(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\entrypoints.py", line 43, in _wrapper
    return main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main.py", line 55, in main
    cmd_name, cmd_args = parse_command(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main_parser.py", line 79, in parse_command
    general_options, args_else = parser.parse_args(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\optparse.py", line 1371, in parse_args
    values = self.get_default_values()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\parser.py", line 279, in get_default_values
    self.config.load()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 124, in load
    self._load_config_files()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 255, in _load_config_files
    parser = self._load_file(variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 261, in _load_file
    logger.verbose("For variant '%s', will try loading '%s'", variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\_log.py", line 23, in verbose
    return self.log(VERBOSE, msg, *args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1512, in log
    self._log(level, msg, args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1589, in _log
    self.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 952, in handle
    self.emit(record)
  File "<string>", line 62, in emit
Message: "For variant '%s', will try loading '%s'"
Arguments: ('user', 'C:\\Users\\Dzenan\\pip\\pip.ini')
--- Logging error ---
Traceback (most recent call last):
  File "<string>", line 60, in emit
KeyError: 15
Call stack:
  File "<string>", line 2, in <module>
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\__init__.py", line 13, in main
    return _wrapper(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\entrypoints.py", line 43, in _wrapper
    return main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main.py", line 55, in main
    cmd_name, cmd_args = parse_command(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main_parser.py", line 79, in parse_command
    general_options, args_else = parser.parse_args(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\optparse.py", line 1371, in parse_args
    values = self.get_default_values()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\parser.py", line 279, in get_default_values
    self.config.load()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 124, in load
    self._load_config_files()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 255, in _load_config_files
    parser = self._load_file(variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 261, in _load_file
    logger.verbose("For variant '%s', will try loading '%s'", variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\_log.py", line 23, in verbose
    return self.log(VERBOSE, msg, *args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1512, in log
    self._log(level, msg, args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1589, in _log
    self.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 952, in handle
    self.emit(record)
  File "<string>", line 62, in emit
Message: "For variant '%s', will try loading '%s'"
Arguments: ('user', 'C:\\Users\\Dzenan\\AppData\\Roaming\\pip\\pip.ini')
--- Logging error ---
Traceback (most recent call last):
  File "<string>", line 60, in emit
KeyError: 15
Call stack:
  File "<string>", line 2, in <module>
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\__init__.py", line 13, in main
    return _wrapper(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\entrypoints.py", line 43, in _wrapper
    return main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main.py", line 55, in main
    cmd_name, cmd_args = parse_command(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main_parser.py", line 79, in parse_command
    general_options, args_else = parser.parse_args(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\optparse.py", line 1371, in parse_args
    values = self.get_default_values()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\parser.py", line 279, in get_default_values
    self.config.load()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 124, in load
    self._load_config_files()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 255, in _load_config_files
    parser = self._load_file(variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 261, in _load_file
    logger.verbose("For variant '%s', will try loading '%s'", variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\_log.py", line 23, in verbose
    return self.log(VERBOSE, msg, *args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1512, in log
    self._log(level, msg, args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1589, in _log
    self.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 952, in handle
    self.emit(record)
  File "<string>", line 62, in emit
Message: "For variant '%s', will try loading '%s'"
Arguments: ('site', 'C:/Users/Dzenan/AppData/Local/slicer.org/Slicer 5.3.0-2023-03-22/bin/../lib/Python\\pip.ini')
--- Logging error ---
Traceback (most recent call last):
  File "<string>", line 60, in emit
KeyError: 15
Call stack:
  File "<string>", line 2, in <module>
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\__init__.py", line 13, in main
    return _wrapper(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\entrypoints.py", line 43, in _wrapper
    return main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main.py", line 70, in main
    return command.main(cmd_args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 101, in main
    return self._main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 114, in _main
    options, args = self.parse_args(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 96, in parse_args
    return self.parser.parse_args(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\optparse.py", line 1371, in parse_args
    values = self.get_default_values()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\parser.py", line 279, in get_default_values
    self.config.load()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 124, in load
    self._load_config_files()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 255, in _load_config_files
    parser = self._load_file(variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 261, in _load_file
    logger.verbose("For variant '%s', will try loading '%s'", variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\_log.py", line 23, in verbose
    return self.log(VERBOSE, msg, *args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1512, in log
    self._log(level, msg, args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1589, in _log
    self.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 952, in handle
    self.emit(record)
  File "<string>", line 62, in emit
Message: "For variant '%s', will try loading '%s'"
Arguments: ('global', 'C:\\ProgramData\\pip\\pip.ini')
--- Logging error ---
Traceback (most recent call last):
  File "<string>", line 60, in emit
KeyError: 15
Call stack:
  File "<string>", line 2, in <module>
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\__init__.py", line 13, in main
    return _wrapper(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\entrypoints.py", line 43, in _wrapper
    return main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main.py", line 70, in main
    return command.main(cmd_args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 101, in main
    return self._main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 114, in _main
    options, args = self.parse_args(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 96, in parse_args
    return self.parser.parse_args(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\optparse.py", line 1371, in parse_args
    values = self.get_default_values()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\parser.py", line 279, in get_default_values
    self.config.load()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 124, in load
    self._load_config_files()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 255, in _load_config_files
    parser = self._load_file(variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 261, in _load_file
    logger.verbose("For variant '%s', will try loading '%s'", variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\_log.py", line 23, in verbose
    return self.log(VERBOSE, msg, *args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1512, in log
    self._log(level, msg, args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1589, in _log
    self.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 952, in handle
    self.emit(record)
  File "<string>", line 62, in emit
Message: "For variant '%s', will try loading '%s'"
Arguments: ('user', 'C:\\Users\\Dzenan\\pip\\pip.ini')
--- Logging error ---
Traceback (most recent call last):
  File "<string>", line 60, in emit
KeyError: 15
Call stack:
  File "<string>", line 2, in <module>
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\__init__.py", line 13, in main
    return _wrapper(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\entrypoints.py", line 43, in _wrapper
    return main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main.py", line 70, in main
    return command.main(cmd_args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 101, in main
    return self._main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 114, in _main
    options, args = self.parse_args(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 96, in parse_args
    return self.parser.parse_args(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\optparse.py", line 1371, in parse_args
    values = self.get_default_values()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\parser.py", line 279, in get_default_values
    self.config.load()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 124, in load
    self._load_config_files()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 255, in _load_config_files
    parser = self._load_file(variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 261, in _load_file
    logger.verbose("For variant '%s', will try loading '%s'", variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\_log.py", line 23, in verbose
    return self.log(VERBOSE, msg, *args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1512, in log
    self._log(level, msg, args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1589, in _log
    self.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 952, in handle
    self.emit(record)
  File "<string>", line 62, in emit
Message: "For variant '%s', will try loading '%s'"
Arguments: ('user', 'C:\\Users\\Dzenan\\AppData\\Roaming\\pip\\pip.ini')
--- Logging error ---
Traceback (most recent call last):
  File "<string>", line 60, in emit
KeyError: 15
Call stack:
  File "<string>", line 2, in <module>
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\__init__.py", line 13, in main
    return _wrapper(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\entrypoints.py", line 43, in _wrapper
    return main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main.py", line 70, in main
    return command.main(cmd_args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 101, in main
    return self._main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 114, in _main
    options, args = self.parse_args(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 96, in parse_args
    return self.parser.parse_args(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\optparse.py", line 1371, in parse_args
    values = self.get_default_values()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\parser.py", line 279, in get_default_values
    self.config.load()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 124, in load
    self._load_config_files()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 255, in _load_config_files
    parser = self._load_file(variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\configuration.py", line 261, in _load_file
    logger.verbose("For variant '%s', will try loading '%s'", variant, fname)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\_log.py", line 23, in verbose
    return self.log(VERBOSE, msg, *args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1512, in log
    self._log(level, msg, args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1589, in _log
    self.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 952, in handle
    self.emit(record)
  File "<string>", line 62, in emit
Message: "For variant '%s', will try loading '%s'"
Arguments: ('site', 'C:/Users/Dzenan/AppData/Local/slicer.org/Slicer 5.3.0-2023-03-22/bin/../lib/Python\\pip.ini')
--- Logging error ---
Traceback (most recent call last):
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\logging.py", line 177, in emit
    self.console.print(renderable, overflow="ignore", crop=False, style=style)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 1715, in print
    self._buffer.extend(new_segments)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 869, in __exit__
    self._exit_buffer()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 827, in _exit_buffer
    self._check_buffer()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 2011, in _check_buffer
    self.file.fileno() in _STD_STREAMS_OUTPUT
AttributeError: 'PythonQtStdOutRedirect' object has no attribute 'fileno'
Call stack:
  File "<string>", line 2, in <module>
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\__init__.py", line 13, in main
    return _wrapper(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\entrypoints.py", line 43, in _wrapper
    return main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main.py", line 70, in main
    return command.main(cmd_args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 101, in main
    return self._main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 214, in _main
    return run(options, args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 160, in exc_logging_wrapper
    status = run_func(*args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\req_command.py", line 247, in wrapper
    return func(self, options, args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\commands\install.py", line 419, in run
    requirement_set = resolver.resolve(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\resolver.py", line 92, in resolve
    result = self._result = resolver.resolve(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 481, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 348, in resolve
    self._add_to_criteria(self.state.criteria, r, parent=None)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 172, in _add_to_criteria
    if not criterion.candidates:
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\structs.py", line 151, in __bool__
    return bool(self._sequence)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\found_candidates.py", line 155, in __bool__
    return any(self)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\found_candidates.py", line 143, in <genexpr>
    return (c for c in iterator if id(c) not in self._incompatible_ids)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\found_candidates.py", line 47, in _iter_built
    candidate = func()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\factory.py", line 206, in _make_candidate_from_link
    self._link_candidate_cache[link] = LinkCandidate(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 297, in __init__
    super().__init__(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 162, in __init__
    self.dist = self._prepare()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 231, in _prepare
    dist = self._prepare_distribution()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 308, in _prepare_distribution
    return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\operations\prepare.py", line 471, in prepare_linked_requirement
    self._log_preparing_link(req)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\operations\prepare.py", line 275, in _log_preparing_link
    logger.info(message, information)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1446, in info
    self._log(INFO, msg, args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1589, in _log
    self.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 952, in handle
    self.emit(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\logging.py", line 179, in emit
    self.handleError(record)
Message: 'Collecting %s'
Arguments: ('pyyaml',)
--- Logging error ---
Traceback (most recent call last):
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\logging.py", line 177, in emit
    self.console.print(renderable, overflow="ignore", crop=False, style=style)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 1715, in print
    self._buffer.extend(new_segments)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 869, in __exit__
    self._exit_buffer()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 827, in _exit_buffer
    self._check_buffer()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 2011, in _check_buffer
    self.file.fileno() in _STD_STREAMS_OUTPUT
AttributeError: 'PythonQtStdOutRedirect' object has no attribute 'fileno'
Call stack:
  File "<string>", line 2, in <module>
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\__init__.py", line 13, in main
    return _wrapper(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\entrypoints.py", line 43, in _wrapper
    return main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main.py", line 70, in main
    return command.main(cmd_args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 101, in main
    return self._main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 214, in _main
    return run(options, args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 160, in exc_logging_wrapper
    status = run_func(*args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\req_command.py", line 247, in wrapper
    return func(self, options, args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\commands\install.py", line 419, in run
    requirement_set = resolver.resolve(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\resolver.py", line 92, in resolve
    result = self._result = resolver.resolve(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 481, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 348, in resolve
    self._add_to_criteria(self.state.criteria, r, parent=None)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 172, in _add_to_criteria
    if not criterion.candidates:
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\structs.py", line 151, in __bool__
    return bool(self._sequence)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\found_candidates.py", line 155, in __bool__
    return any(self)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\found_candidates.py", line 143, in <genexpr>
    return (c for c in iterator if id(c) not in self._incompatible_ids)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\found_candidates.py", line 47, in _iter_built
    candidate = func()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\factory.py", line 206, in _make_candidate_from_link
    self._link_candidate_cache[link] = LinkCandidate(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 297, in __init__
    super().__init__(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 162, in __init__
    self.dist = self._prepare()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 231, in _prepare
    dist = self._prepare_distribution()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 308, in _prepare_distribution
    return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\operations\prepare.py", line 491, in prepare_linked_requirement
    return self._prepare_linked_requirement(req, parallel_builds)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\operations\prepare.py", line 536, in _prepare_linked_requirement
    local_file = unpack_url(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\operations\prepare.py", line 166, in unpack_url
    file = get_http_url(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\operations\prepare.py", line 107, in get_http_url
    from_path, content_type = download(link, temp_dir.path)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\network\download.py", line 145, in __call__
    chunks = _prepare_download(resp, link, self._progress_bar)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\network\download.py", line 50, in _prepare_download
    logger.info("Downloading %s", logged_url)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1446, in info
    self._log(INFO, msg, args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1589, in _log
    self.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 952, in handle
    self.emit(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\logging.py", line 179, in emit
    self.handleError(record)
Message: 'Downloading %s'
Arguments: ('PyYAML-6.0-cp39-cp39-win_amd64.whl (151 kB)',)
--- Logging error ---
Traceback (most recent call last):
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 160, in exc_logging_wrapper
    status = run_func(*args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\req_command.py", line 247, in wrapper
    return func(self, options, args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\commands\install.py", line 419, in run
    requirement_set = resolver.resolve(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\resolver.py", line 92, in resolve
    result = self._result = resolver.resolve(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 481, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 348, in resolve
    self._add_to_criteria(self.state.criteria, r, parent=None)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 172, in _add_to_criteria
    if not criterion.candidates:
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\structs.py", line 151, in __bool__
    return bool(self._sequence)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\found_candidates.py", line 155, in __bool__
    return any(self)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\found_candidates.py", line 143, in <genexpr>
    return (c for c in iterator if id(c) not in self._incompatible_ids)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\found_candidates.py", line 47, in _iter_built
    candidate = func()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\factory.py", line 206, in _make_candidate_from_link
    self._link_candidate_cache[link] = LinkCandidate(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 297, in __init__
    super().__init__(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 162, in __init__
    self.dist = self._prepare()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 231, in _prepare
    dist = self._prepare_distribution()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 308, in _prepare_distribution
    return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\operations\prepare.py", line 491, in prepare_linked_requirement
    return self._prepare_linked_requirement(req, parallel_builds)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\operations\prepare.py", line 536, in _prepare_linked_requirement
    local_file = unpack_url(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\operations\prepare.py", line 166, in unpack_url
    file = get_http_url(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\operations\prepare.py", line 107, in get_http_url
    from_path, content_type = download(link, temp_dir.path)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\network\download.py", line 147, in __call__
    for chunk in chunks:
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\progress_bars.py", line 55, in _rich_progress_bar
    progress.update(task_id, advance=len(chunk))
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\progress.py", line 1178, in __exit__
    self.stop()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\progress.py", line 1164, in stop
    self.live.stop()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\live.py", line 163, in stop
    self.ipy_widget.close()  # pragma: no cover
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 869, in __exit__
    self._exit_buffer()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 827, in _exit_buffer
    self._check_buffer()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 2011, in _check_buffer
    self.file.fileno() in _STD_STREAMS_OUTPUT
AttributeError: 'PythonQtStdOutRedirect' object has no attribute 'fileno'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\logging.py", line 177, in emit
    self.console.print(renderable, overflow="ignore", crop=False, style=style)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 1715, in print
    self._buffer.extend(new_segments)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 869, in __exit__
    self._exit_buffer()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 827, in _exit_buffer
    self._check_buffer()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 2011, in _check_buffer
    self.file.fileno() in _STD_STREAMS_OUTPUT
AttributeError: 'PythonQtStdOutRedirect' object has no attribute 'fileno'
Call stack:
  File "<string>", line 2, in <module>
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\__init__.py", line 13, in main
    return _wrapper(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\entrypoints.py", line 43, in _wrapper
    return main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main.py", line 70, in main
    return command.main(cmd_args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 101, in main
    return self._main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 214, in _main
    return run(options, args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 202, in exc_logging_wrapper
    logger.critical("Exception:", exc_info=True)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1493, in critical
    self._log(CRITICAL, msg, args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1589, in _log
    self.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 952, in handle
    self.emit(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\logging.py", line 179, in emit
    self.handleError(record)
Message: 'Exception:'
Arguments: ()
WARNING: pip is being invoked by an old script wrapper. This will fail in a future version of pip.
Please see https://github.com/pypa/pip/issues/5599 for advice on fixing the underlying issue.
To avoid this problem you can invoke Python with '-m pip' instead of running pip directly.
--- Logging error ---
Traceback (most recent call last):
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\factory.py", line 158, in _make_candidate_from_dist
    base = self._installed_candidate_cache[dist.canonical_name]
KeyError: 'pyzmq'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\logging.py", line 177, in emit
    self.console.print(renderable, overflow="ignore", crop=False, style=style)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 1715, in print
    self._buffer.extend(new_segments)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 869, in __exit__
    self._exit_buffer()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 827, in _exit_buffer
    self._check_buffer()
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\rich\console.py", line 2011, in _check_buffer
    self.file.fileno() in _STD_STREAMS_OUTPUT
AttributeError: 'PythonQtStdOutRedirect' object has no attribute 'fileno'
Call stack:
  File "<string>", line 3, in <module>
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\__init__.py", line 13, in main
    return _wrapper(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\entrypoints.py", line 43, in _wrapper
    return main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\main.py", line 70, in main
    return command.main(cmd_args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 101, in main
    return self._main(args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 214, in _main
    return run(options, args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\base_command.py", line 160, in exc_logging_wrapper
    status = run_func(*args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\cli\req_command.py", line 247, in wrapper
    return func(self, options, args)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\commands\install.py", line 419, in run
    requirement_set = resolver.resolve(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\resolver.py", line 92, in resolve
    result = self._result = resolver.resolve(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 481, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 348, in resolve
    self._add_to_criteria(self.state.criteria, r, parent=None)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_vendor\resolvelib\resolvers.py", line 147, in _add_to_criteria
    matches = self._p.find_matches(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\provider.py", line 224, in find_matches
    return self._factory.find_candidates(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\factory.py", line 424, in find_candidates
    return self._iter_found_candidates(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\factory.py", line 320, in _iter_found_candidates
    _get_installed_candidate(),
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\factory.py", line 268, in _get_installed_candidate
    candidate = self._make_candidate_from_dist(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\factory.py", line 160, in _make_candidate_from_dist
    base = AlreadyInstalledCandidate(dist, template, factory=self)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 354, in __init__
    factory.preparer.prepare_installed_requirement(self._ireq, skip_reason)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\operations\prepare.py", line 656, in prepare_installed_requirement
    logger.info(
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1446, in info
    self._log(INFO, msg, args, **kwargs)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1589, in _log
    self.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\logging\__init__.py", line 952, in handle
    self.emit(record)
  File "C:\Users\Dzenan\AppData\Local\slicer.org\Slicer 5.3.0-2023-03-22\lib\Python\Lib\site-packages\pip\_internal\utils\logging.py", line 179, in emit
    self.handleError(record)
Message: 'Requirement %s: %s (%s)'
Arguments: ('already satisfied', <InstallRequirement object: pyzmq in c:\users\dzenan\appdata\local\slicer.org\slicer 5.3.0-2023-03-22\lib\python\lib\site-packages editable=False>, <Version('25.0.2')>)
>>> slicer.util.pip_install("pyyaml")
Collecting pyyaml
  Using cached PyYAML-6.0-cp39-cp39-win_amd64.whl (151 kB)
Installing collected packages: pyyaml
Successfully installed pyyaml-6.0
>>> slicer.util.pip_install("pyzmq")
Requirement already satisfied: pyzmq in c:\users\dzenan\appdata\local\slicer.org\slicer 5.3.0-2023-03-22\lib\python\lib\site-packages (25.0.2)
>>>
```